### PR TITLE
Añadir servicios de aplicación y comportamientos de pipeline

### DIFF
--- a/src/CleanArchitecture/Core/CleanArchitecture.Application/ApplicationServiceRegistration.cs
+++ b/src/CleanArchitecture/Core/CleanArchitecture.Application/ApplicationServiceRegistration.cs
@@ -1,0 +1,22 @@
+﻿using MediatR;
+using FluentValidation;
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using CleanArchitecture.Application.Behaviours;
+
+namespace CleanArchitecture.Application
+{
+    public static class ApplicationServiceRegistration
+    {
+        public static IServiceCollection AddApplicationServices(this IServiceCollection services)
+        {
+            services.AddAutoMapper(Assembly.GetExecutingAssembly());
+            services.AddValidatorsFromAssembly(Assembly.GetExecutingAssembly());
+            services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(Assembly.GetExecutingAssembly())); // Fix the AddMediatR call
+            services.AddTransient(typeof(IPipelineBehavior<,>), typeof(UnhandleExceptionBehaviour<,>));
+            services.AddTransient(typeof(IPipelineBehavior<,>), typeof(ValidationBehaviour<,>));
+
+            return services;
+        }
+    }
+}


### PR DESCRIPTION
Se ha añadido la importación de los espacios de nombres necesarios: `MediatR`, `FluentValidation`, `System.Reflection`, `Microsoft.Extensions.DependencyInjection` y
`CleanArchitecture.Application.Behaviours`.

Se ha creado el espacio de nombres `CleanArchitecture.Application` con la clase estática `ApplicationServiceRegistration`.

Dentro de `ApplicationServiceRegistration`, se ha añadido el método de extensión `AddApplicationServices` para `IServiceCollection`.

En `AddApplicationServices`, se han registrado los siguientes servicios:
- `AddAutoMapper` para el ensamblado actual.
- `AddValidatorsFromAssembly` para el ensamblado actual.
- `AddMediatR` con una corrección en la llamada para registrar servicios desde el ensamblado actual.
- `AddTransient` para registrar los comportamientos de pipeline `UnhandleExceptionBehaviour` y `ValidationBehaviour`.